### PR TITLE
Implement GET endpoints for group's members and owners

### DIFF
--- a/db/groups.js
+++ b/db/groups.js
@@ -168,6 +168,10 @@ exports.getUserGroups = function(username, callback) {
     }
     err ? callback(err) : callback(rows.rows);
   });
+};
+
+exports.getGroupMembers = function(groupID, callback) {
+
 
 
 };

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -69,10 +69,20 @@ exports.updateUser = function(req, res) {
   // send in old pw as new pw if user does not change it, same for email
 };
 
+// get the groups a user is in
 exports.getUserGroups = function(req, res) {
   var username = req.query.username || req.body.username;
 
   groups.getUserGroups(username, function(err, result) {
+    err ? res.send(err) : res.send(result);
+  });
+}
+
+// get the users belonging to a group
+exports.getGroupMembers = function(req, res) {
+  var groupID = req.query.groupID || req.body.groupID;
+
+  groups.getGroupMembers(groupID, function(err, result) {
     err ? res.send(err) : res.send(result);
   });
 }

--- a/server/server.js
+++ b/server/server.js
@@ -24,6 +24,7 @@ app.use('/api/users/update', sessionChecker, routes.updateUser);
 app.use('/api/users/groups', sessionChecker, routes.getUserGroups); // done
 app.use('/api/groups/create', sessionChecker, routes.createGroup); // done
 app.use('/api/groups/add', sessionChecker, routes.addMember); // done
+app.use('/api/groups/users', sessionChecker, routes.getGroupMembers);
 app.use('/api/websites/create', sessionChecker, routes.createSite);
 app.use('/api/markups/create', sessionChecker, routes.createMarkup);
 app.use('/api/groups/markups', sessionChecker, routes.markupGroup);
@@ -33,6 +34,7 @@ app.use('/api/groups/sites', sessionChecker, routes.shareSite);
 app.use('/test/groups/create', routes.createGroup);
 app.use('/test/groups/add', routes.addMember);
 app.use('/test/users/groups', routes.getUserGroups);
+app.use('/test/groups/users', routes.getGroupMembers);
 
 
 


### PR DESCRIPTION
Exposed endpoint (authenticated): `/api/groups/users`
Exposed endpoint (temp, non-authenticated): `/test/groups/users`

Accepts: `GET` request with single parameter: groupID
Returns: `err, result`
