### PR TITLE
Implement markup creation endpoint + DB

### DIFF
--- a/db/groups.js
+++ b/db/groups.js
@@ -80,7 +80,7 @@ exports.createGroup = function(groupName, owner, callback) {
 
 exports.addMember = function(groupID, username, newMember, callback) {
 
-  console.log('/**', username, 'is adding:', newMember, 'to group:', groupID);
+  console.log('/**', username, 'is adding:', newMember, 'to group:', groupID, '**/');
 
   pool.query({
     // check if new user exists

--- a/db/groups.js
+++ b/db/groups.js
@@ -13,6 +13,8 @@ var pool = new Pool(CONFIG);
 
 exports.createGroup = function(groupName, owner, callback) {
 
+  console.log('/** Creating Group:', groupName, 'for:', owner, '**/');
+
   pool.query({
     text: 'SELECT ug.groupid, ug.userid FROM users u \
       LEFT JOIN usersgroups ug \
@@ -77,6 +79,8 @@ exports.createGroup = function(groupName, owner, callback) {
 };
 
 exports.addMember = function(groupID, username, newMember, callback) {
+
+  console.log('/**', username, 'is adding:', newMember, 'to group:', groupID);
 
   pool.query({
     // check if new user exists

--- a/db/groups.js
+++ b/db/groups.js
@@ -11,7 +11,7 @@ var CONFIG = {
 
 var pool = new Pool(CONFIG);
 
-exports.createGroup = function(groupName, owner, callback) {
+exports.create = function(groupName, owner, callback) {
 
   console.log('/** Creating Group:', groupName, 'for:', owner, '**/');
 
@@ -78,7 +78,7 @@ exports.createGroup = function(groupName, owner, callback) {
   });
 };
 
-exports.addMember = function(groupID, username, newMember, callback) {
+exports.add = function(groupID, username, newMember, callback) {
 
   console.log('/**', username, 'is adding:', newMember, 'to group:', groupID, '**/');
 
@@ -177,37 +177,7 @@ exports.addMember = function(groupID, username, newMember, callback) {
   });
 };
 
-exports.getUserGroups = function(username, callback) {
-
-  pool.query({
-    // find all groups user is a part of (and their owners)
-    text: 'SELECT u.id AS userid, g.id AS groupid, g.name AS groupname, \
-      g.owner AS groupowner FROM users u \
-      LEFT JOIN usersgroups ug \
-      ON u.id = ug.userid \
-      LEFT JOIN groups g \
-      ON g.id = ug.groupid \
-      WHERE userid IN ( \
-        SELECT u.id FROM users u \
-        WHERE u.username = \'' + username + '\' \
-      );'
-      // TODO implement invisible-group ignore
-  }, 
-
-  function(err, rows) {
-    if (err) {
-      callback(err, null);
-    } else {
-      if (rows.rowCount === 0) {
-        callback('user is not part of any groups', null);
-      } else {
-        callback(null, rows.rows);
-      }
-    }
-  });
-};
-
-exports.getGroupMembers = function(groupID, callback) {
+exports.getMembers = function(groupID, callback) {
 
   pool.query({
     text: 'SELECT member, groupname, u2.username AS owner FROM ( \

--- a/db/markups.js
+++ b/db/markups.js
@@ -1,0 +1,20 @@
+var pg = require('pg');
+var Pool = require('pg').Pool;
+var Promise = require('es6-promise').Promise;
+
+var CONFIG = {
+  host: 'localhost',
+  user: 'admin',
+  password: 'rQUNyC8W9YT7ZZBW',
+  database: 'markable'
+};
+
+var pool = new Pool(CONFIG);
+
+exports.create = function() {
+
+};
+
+exports.share = function() {
+
+};

--- a/db/markups.js
+++ b/db/markups.js
@@ -11,8 +11,96 @@ var CONFIG = {
 
 var pool = new Pool(CONFIG);
 
-exports.create = function() {
+exports.create = function(url, title, username, anchor, text, comment, callback) {
 
+  console.log('Creating private markup:', text, 'for username:', username, 'on site:', url, title, 'with the following comment:', comment);
+
+  var authorID;
+  var siteID;
+
+  pool.query({
+    // find user ID
+    text: 'SELECT * FROM users \
+      WHERE username = \'' + username + '\';'
+  },
+
+  function(err, rows) {
+    if (err) {
+      callback(err, null);
+    } else {
+      if (rows.rowCount === 0) {
+        callback('user does not exist', null);
+      } else {
+        authorID = rows.rows[0].id;
+
+        pool.query({
+          // find site with same URL and title
+          text: 'SELECT * FROM sites \
+            WHERE url = \'' + url + '\' \
+            AND title = \'' + title + '\';'
+        },
+
+        function(err2, rows2) {
+          if (err2) {
+            callback(err2, null);
+          } else {
+            if (rows.rowCount > 0) {
+              siteID = rows2.rows[0].id;
+
+              pool.query({
+                // insert into markups
+                text: 'INSERT INTO markups(siteid, authorid, anchor, text, comment) \
+                  VALUES($1, $2, $3, $4, $5)', 
+                values: [siteID, authorID, anchor, text, comment]
+              },
+
+              function(err3, rows3) {
+                if (err3) {
+                  callback(err3, null);
+                } else {
+                  callback(null, true);
+                }
+              });
+
+            } else {
+
+              pool.query({
+                // insert site into the sites table
+                text: 'INSERT INTO sites(url, title) \
+                  VALUES($1, $2) \
+                  RETURNING *',
+                values: [url, title]
+              },
+
+              function(err4, rows4) {
+                if (err4) {
+                  callback(err4, null);
+                } else {
+
+                  siteID = rows4.rows[0].id;
+
+                  pool.query({
+                    // insert into markups
+                    text: 'INSERT INTO markups(siteid, authorid, anchor, text, comment) \
+                      VALUES($1, $2, $3, $4, $5)', 
+                    values: [siteID, authorID, anchor, text, comment]
+                  },
+
+                  function(err5, rows5) {
+                    if (err5) {
+                      callback(err5, null);
+                    } else {
+                      callback(null, true);
+                    }
+                  });
+                }
+              })
+            }
+          }
+        });
+      }
+    }
+  });
 };
 
 exports.share = function() {

--- a/db/users.js
+++ b/db/users.js
@@ -11,7 +11,7 @@ var CONFIG = {
 
 var pool = new Pool(CONFIG);
 
-exports.insertUser = function(username, email, password, callback) {
+exports.insert = function(username, email, password, callback) {
 
   pool.query({
     text: 'SELECT username FROM users \
@@ -36,7 +36,7 @@ exports.insertUser = function(username, email, password, callback) {
   });
 };
 
-exports.checkUser = function(username, password, callback) {
+exports.check = function(username, password, callback) {
 
   pool.query({
     text: 'SELECT username, password FROM users \
@@ -48,6 +48,36 @@ exports.checkUser = function(username, password, callback) {
   });
 };
 
-exports.updateUser = function(username, password, newPassword, email, newEmail, callback) {
+exports.update = function(username, password, newPassword, email, newEmail, callback) {
   // TODO: implement user updating
 }
+
+
+exports.getGroups = function(username, callback) {
+
+  pool.query({
+    // find all groups user is a part of (and their owners)
+    text: 'SELECT u.id AS userid, g.id AS groupid, g.name AS groupname, \
+      g.owner AS groupowner FROM users u \
+      LEFT JOIN usersgroups ug \
+      ON u.id = ug.userid \
+      LEFT JOIN groups g \
+      ON g.id = ug.groupid \
+      WHERE userid IN ( \
+        SELECT u.id FROM users u \
+        WHERE u.username = \'' + username + '\' \
+      );'
+  }, 
+
+  function(err, rows) {
+    if (err) {
+      callback(err, null);
+    } else {
+      if (rows.rowCount === 0) {
+        callback('user is not part of any groups', null);
+      } else {
+        callback(null, rows.rows);
+      }
+    }
+  });
+};

--- a/db/websites.js
+++ b/db/websites.js
@@ -11,7 +11,7 @@ var CONFIG = {
 
 var pool = new Pool(CONFIG);
 
-exports.createSite = function(url, title, callback) {
+exports.create = function(url, title, callback) {
 
   pool.query({
     // check if website already exists
@@ -38,7 +38,7 @@ exports.createSite = function(url, title, callback) {
   });
 };
 
-exports.shareSite = function(username, groupID, url, title, callback) {
+exports.share = function(username, groupID, url, title, callback) {
 
   console.log('/**', username, 'is sharing:', url, '(', title, ') with group:', groupID);
 

--- a/db/websites.js
+++ b/db/websites.js
@@ -40,6 +40,8 @@ exports.createSite = function(url, title, callback) {
 
 exports.shareSite = function(username, groupID, url, title, callback) {
 
+  console.log('/**', username, 'is sharing:', url, '(', title, ') with group:', groupID);
+
   var siteID;
 
   pool.query({

--- a/db/websites.js
+++ b/db/websites.js
@@ -70,8 +70,8 @@ exports.share = function(username, groupID, url, title, callback) {
             );'
         },
 
-        function(err3, rows3) {
-          err3 ? callback(err3, null) : callback(null, true);
+        function(err2, rows2) {
+          err2 ? callback(err3, null) : callback(null, true);
         });
       } else {
 
@@ -82,10 +82,12 @@ exports.share = function(username, groupID, url, title, callback) {
           values: [url, title]
         },
 
-        function(err2, rows2) {
-          if (err2) {
-            callback(err2, null);
+        function(err3, rows3) {
+          if (err3) {
+            callback(err3, null);
           } else {
+
+            siteID = rows3.rows[0].id;
 
             pool.query({
               text: 'INSERT INTO sitesgroups \

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -27,19 +27,13 @@ exports.createUser = function(req, res) {
     } else {
       password = hash;
 
-      users.insertUser(username, email, password, function(err, result) {
+      users.insert(username, email, password, function(err, result) {
         if (err) {
-          res.send(err)
+          res.send(err);
         } else {
           createSession(req, res, username, function() {
-            console.log(req.session); // TODO remove
-            var groupName = 'invisible-' + username;
-
-            groups.createGroup(groupName, username, function(err3, success2) {
-              err3 ? res.send(err3) : res.send(success2);
-            });
+            res.send(result);
           });
-          
         }
       });
     }
@@ -50,7 +44,7 @@ exports.checkUser = function(req, res) {
   var username = req.query.username || req.body.username;
   var password = req.query.password || req.body.password;
 
-  users.checkUser(username, password, function(err, result) {
+  users.check(username, password, function(err, result) {
     if (err) {
       res.send(err);
     } else {
@@ -58,13 +52,14 @@ exports.checkUser = function(req, res) {
         res.send('user does not exist');
       } else {        
         var retrievedPassword = result.rows[0].password;
+
         bcrypt.compare(password, retrievedPassword, function(err2, success) {
           if (success) {
             createSession(req, res, username, function(){
               res.send(success);
             });
           } else {
-            res.send(success);
+            res.send(err2);
           }
         });
       }
@@ -81,7 +76,7 @@ exports.updateUser = function(req, res) {
 exports.getUserGroups = function(req, res) {
   var username = req.query.username || req.body.username;
 
-  groups.getUserGroups(username, function(err, result) {
+  users.getGroups(username, function(err, result) {
     err ? res.send(err) : res.send(result);
   });
 }
@@ -94,7 +89,7 @@ exports.getUserGroups = function(req, res) {
 exports.getGroupMembers = function(req, res) {
   var groupID = req.query.groupID || req.body.groupID;
 
-  groups.getGroupMembers(groupID, function(err, result) {
+  groups.getMembers(groupID, function(err, result) {
     err ? res.send(err) : res.send(result);
   });
 }
@@ -103,7 +98,7 @@ exports.createGroup = function(req, res) {
   var groupName = req.query.groupName || req.body.groupName;
   var owner = req.query.owner || req.body.owner;
 
-  groups.createGroup(groupName, owner, function(err, success) {
+  groups.create(groupName, owner, function(err, success) {
     err ? res.send(err) : res.send(success);
   });
 };
@@ -124,7 +119,7 @@ exports.addMember = function(req, res) {
   7. Insert member + group into UG join table 
   */
 
-  groups.addMember(groupID, username, newMember, function(err, success) {
+  groups.add(groupID, username, newMember, function(err, success) {
     err ? res.send(err) : res.send(success);
   });
 };
@@ -152,7 +147,7 @@ exports.createSite = function(req, res) {
   var url = req.query.url || req.body.url;
   var title = req.query.title || req.body.title;
 
-  websites.createSite(url, title, function(err, success) {
+  websites.create(url, title, function(err, success) {
     err ? res.send(err) : res.send(success);
   });
 };
@@ -171,7 +166,7 @@ exports.shareSite = function(req, res) {
   4. Use siteID, groupID, sharedtime as PK
   */
 
-  websites.shareSite(username, groupID, url, title, function(err, success) {
+  websites.share(username, groupID, url, title, function(err, success) {
     err ? res.send(err) : res.send(success);
   })
 

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -183,7 +183,16 @@ exports.deleteSite = function(req, res) {
 ****************************************************/
 
 exports.createMarkup = function(req, res) {
-  markups.create();
+  var url = req.query.url || req.body.url;
+  var title = req.query.title || req.body.title;
+  var username = req.query.username || req.body.username;
+  var anchor = req.query.anchor || req.body.anchor;
+  var text = req.query.text || req.body.text;
+  var comment = req.query.comment || req.body.comment;
+
+  markups.create(url, title, username, anchor, text, comment, function(err, success) {
+    err ? res.send(err) : res.send(success);
+  });
 };
 
 exports.shareMarkup = function(req, res) {

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -190,6 +190,16 @@ exports.createMarkup = function(req, res) {
   var text = req.query.text || req.body.text;
   var comment = req.query.comment || req.body.comment;
 
+  /** 
+  DB Logic for markup creation:
+  1. Find userID from username
+  2. Find siteID from site, if found, use siteID
+  3. If not found, insert site and use siteID
+  4. Insert into markup table:
+    siteID, authorID, anchor, text, comment
+  5. Callback true
+  **/
+
   markups.create(url, title, username, anchor, text, comment, function(err, success) {
     err ? res.send(err) : res.send(success);
   });

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -1,6 +1,7 @@
 var users = require('../../db/users');
 var groups = require('../../db/groups');
 var websites = require('../../db/websites');
+var markups = require('../../db/markups');
 
 var bcrypt = require('bcrypt');
 var saltRounds = 10;
@@ -187,11 +188,11 @@ exports.deleteSite = function(req, res) {
 ****************************************************/
 
 exports.createMarkup = function(req, res) {
-
+  markups.create();
 };
 
 exports.shareMarkup = function(req, res) {
-
+  markups.share();
 };
 
 exports.deleteMarkup = function(req, res) {

--- a/server/server.js
+++ b/server/server.js
@@ -61,6 +61,8 @@ app.use('/test/users/groups', routes.getUserGroups);
 app.use('/test/groups/users', routes.getGroupMembers);
 app.use('/test/websites/create', routes.createSite);
 app.use('/test/websites/share', routes.shareSite);
+app.use('/test/markups/create', routes.createMarkup);
+app.use('/test/markups/share', routes.shareMarkup);
 
 
 

--- a/server/server.js
+++ b/server/server.js
@@ -1,6 +1,5 @@
 var express = require('express');
 var bodyParser = require('body-parser');
-// var handlers = require('./ORMhandlers');
 var app = express();
 var routes = require('./routes/routes');
 var session = require('express-session');


### PR DESCRIPTION
Includes a back-end refactor of all previous endpoints (does not affect how the client attempts to access these endpoints).

New endpoint is accessible from `/api/markups/create` or the temporary non-authenticated route: `/test/markups/create`.

Endpoint expects the following in the data object:
`url`: The URL of the site the user is currently on
`title`: The title of the site the user is currently on
`username`: The current user's username
`anchor`: The selection the user has made (how we reference and restore at a future time)
`text`: What the user has highlighted
`comment`: Any comments the user has attached to the markup
